### PR TITLE
Add JustBlogged to Marketing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Find lean, reliable software built by bootstrapped founders who prioritize usabi
 ## HR & People Ops
 
 ## Marketing
+- [JustBlogged](https://justblogged.com) - No-setup blogging platform. Start your blog in 2 minutes. Free plan available, $9/mo for Pro with custom domains and built-in SEO.
 
 - [Leado](https://leado.co) - AI-powered Reddit lead generation tool that monitors subreddits for high-intent conversations and automates outreach.
 


### PR DESCRIPTION
Adding [JustBlogged](https://justblogged.com) — a bootstrapped, no-setup blogging platform. Sign up, pick a name, start writing in 2 minutes. Free plan available, $9/mo for Pro with custom domains, beautiful themes, and built-in SEO.