### PR TITLE
Add Snaplert to Utilities section

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Find lean, reliable software built by bootstrapped founders who prioritize usabi
 
 ## Utilities
 
+- [Snaplert](https://snaplert.com) - Monitor any webpage for changes and get email alerts with before/after pixel diffs and AI summaries. Element-level zone picker. Free during open beta.
 - [Presentify](https://presentifyapp.com) - Annotate Screen. Highlight, Spotlight, and Zoom Cursor.
 - [FaceScreen](https://facescreenapp.com) - Show your face and brand on top of everything else.
 - [KeyScreen](https://keyscreenapp.com) - Show key presses on your screen.


### PR DESCRIPTION
Adds [Snaplert](https://snaplert.com) to the Utilities section.

Snaplert is a bootstrapped website change monitoring tool:
- Paste any URL, pick the zone to watch, get email alerts when it changes
- Before/after pixel diff screenshots + AI summaries (Claude) explaining what changed
- Element-level zone picker reduces false positives vs. traditional screenshot monitoring
- Checks every 5 minutes, 24/7
- Free during open beta, paid plans start at $19/mo
- Built by an indie founder with no VC backing