### PR TITLE
Add Tapetide to Finance & Accounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Find lean, reliable software built by bootstrapped founders who prioritize usabi
 
 ## Finance & Accounting
 
+- [Tapetide](https://tapetide.com) - AI-first stock research for Indian markets (NSE & BSE) with a natural-language assistant, a 326-ratio screener, financials, and FII/DII flows.
+
 ## HR & People Ops
 
 ## Marketing


### PR DESCRIPTION
Adds **Tapetide** to the **Finance & Accounting** section (currently empty — this is the first entry).

`- [Tapetide](https://tapetide.com) - AI-first stock research for Indian markets (NSE & BSE) with a natural-language assistant, a 326-ratio screener, financials, and FII/DII flows.`

Meets the quality criteria: built by a bootstrapped solo founder (not VC-backed), live product, usability-focused with a free tier and no paywall on core data. Follows the entry format. No duplicate.