### PR TITLE
Add SellerMind to SEO category

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Find lean, reliable software built by bootstrapped founders who prioritize usabi
 
 ## SEO
 
+- [SellerMind](https://thesellermind.com) - Indie-built Etsy SEO research tool with keyword volume, competitor analysis, listing optimizer, and an AI-assisted listing rewriter. One Pro plan at $19.99/mo or $199/yr.
+
 ## Utilities
 
 - [Presentify](https://presentifyapp.com) - Annotate Screen. Highlight, Spotlight, and Zoom Cursor.


### PR DESCRIPTION
Adds [SellerMind](https://thesellermind.com) to the **SEO** category (currently empty).

**Description:** SellerMind is a friendlier, cheaper Etsy SEO research tool built by an indie maker. Single Pro plan ($19.99/mo or $199/yr) — no six-tier pricing maze — covering keyword volume, competition data, AI-assisted listing rewriter (title, tags, description), competitor snapshots, and trend / seasonality views.

**Why it fits the quality criteria:**
- ✅ Built by a bootstrapped solo founder (no VC funding).
- ✅ Transparent, sane pricing (one paid plan, no upsells).
- ✅ Actively maintained.
- ✅ Founder answers his own customer emails (fast support).

**Format check:** `- [Software Name](link) - Description.` per CONTRIBUTING.md, alphabetical (only entry in the section), no affiliate links.

Homepage: https://thesellermind.com