### PR TITLE
Add HonorBox to E-commerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Find lean, reliable software built by bootstrapped founders who prioritize usabi
 
 ## E-commerce
 
+- [HonorBox](https://honorboxx.github.io/honorbox/) - Sell digital products with just Stripe and GitHub: static storefront, checkout via Stripe Payment Links, delivery via private repo invites. MIT engine, $0/month, 0% platform fee.
+
 ## Finance & Accounting
 
 - [Netkiln](https://netkiln.com) - Paste a payouts CSV; get a public client-ready revenue-health page for freelancers and agencies. Free draft; $19 clean unlock.


### PR DESCRIPTION
Adds [HonorBox](https://github.com/Honorboxx/honorbox) to the (currently empty) E-commerce section, matching the entry format used elsewhere in the README.

HonorBox is an MIT-licensed engine for selling digital products with no server: a static storefront on GitHub Pages, checkout through the seller's own Stripe account via Payment Links, and a scheduled GitHub Action that delivers each sale by inviting the buyer's GitHub account to a private repo. Zero-dependency Node, sane transparent pricing (the engine is free; an optional $29 Pro pack funds it).

Disclosure: I maintain HonorBox, so this is a self-submission. Happy to adjust wording or placement if you prefer.