### PR TITLE
Add llm-tokencheck to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Find lean, reliable software built by bootstrapped founders who prioritize usabi
 - [NoParam](https://noparam.com) - Real-time email validation API to prevent fake signups, detect disposable addresses, and ensure deliverability.
 - [Web Maker](https://webmaker.app) - The fastest and offline and frontend playground.
 - [Rocketship](https://github.com/rocketship-ai/rocketship) - A QA testing framework for your coding agent.
+- [llm-tokencheck](https://github.com/ilan-lachkar/llm-tokencheck) - Free CLI that estimates LLM API tokens + USD cost across Anthropic, OpenAI and Google models before you send the request. Optional $9 one-time Pro license for batch folder processing + CSV export.
 
 ## E-commerce
 


### PR DESCRIPTION
Adds [llm-tokencheck](https://github.com/ilan-lachkar/llm-tokencheck), a free open-source CLI (`npm i -g llm-tokencheck`) that estimates LLM API token count + USD cost across Anthropic, OpenAI and Google models before you send the request. Optional $9 one-time Pro license unlocks batch folder processing + CSV export — no subscription, no VC funding, built and maintained solo.

Disclosure: I'm the author.