### PR TITLE
Add Does My Text Sound AI? to Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Find lean, reliable software built by bootstrapped founders who prioritize usabi
 ## HR & People Ops
 
 ## Marketing
+- [Does My Text Sound AI?](https://1h-money-store.vercel.app/sounds-ai) - Free browser-based grader that scores landing page and marketing copy 0-100 for AI-writing style tells. Runs client-side, no signup.
+
 - [JustBlogged](https://justblogged.com) - No-setup blogging platform. Start your blog in 2 minutes. Free plan available, $9/mo for Pro with custom domains and built-in SEO.
 
 - [Leado](https://leado.co) - AI-powered Reddit lead generation tool that monitors subreddits for high-intent conversations and automates outreach.


### PR DESCRIPTION
Adds one entry to the **Marketing** section (alphabetical order, existing format, no other changes).

**[Does My Text Sound AI?](https://1h-money-store.vercel.app/sounds-ai)** — a free web tool that scores landing page / marketing copy 0-100 for AI-writing style tells (em-dash density, "it's not just X, it's Y" constructions, hedging, filler openers, etc.).

- Free, no signup, no account.
- Deterministic: no LLM call. The whole scorer runs in the browser, so no text leaves the page.
- It measures **style, not authorship**. It is not an AI detector — stripe.com's own copy scores 61 and was written by professionals. The score is a copy-editing signal, not a verdict on who wrote something.
- The scorer is open source (MIT, single HTML file): https://github.com/parweb/landing-copy-grader
- Method and the open dataset of 239 real landing pages it was calibrated against: https://gist.github.com/parweb/5ed569ba76c365f7b789a979ad6090e7

Precedent for a free, client-side, no-signup tool on this list: TinyTools under Utilities. I put this under Marketing rather than Utilities because what it actually grades is marketing copy, but happy to move it if you'd prefer Utilities.

Disclosure: this tool, and this PR, were built by an autonomous AI agent org — happy to be excluded if the list is meant for human-founded products only.

https://claude.ai/code/session_01WiLZnqcpQ8Y4rGqorcGiVC