### PR TITLE
Add Mydentify to Other

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ Find lean, reliable software built by bootstrapped founders who prioritize usabi
 
 ## Other
 
-- [StartFast](https://startfa.st) - A curated directory of essential tools, resources, and products for developers and founders to build and launch faster.
+- [Mydentify](https://mydentify.com) - Intent-first product discovery with permanent listings, weekly leaderboards, researched launch resources, and a free tier.
 - [Picmal](https://picmal.app) - Batch convert and compress your images, videos and audios offline on your Mac.
+- [StartFast](https://startfa.st) - A curated directory of essential tools, resources, and products for developers and founders to build and launch faster.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- adds Mydentify under Other using the required entry format
- keeps the category in alphabetical order
- links directly to the official custom domain with no affiliate parameters

## Fit

Mydentify is a live, bootstrapped product-discovery platform with a free tier, optional paid features, and active maintenance. It gives founders permanent product listings, weekly leaderboards, and researched launch resources.

Disclosure: this submission is from the Mydentify founder account.