### PR TITLE
Add Autoposting to Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Find lean, reliable software built by bootstrapped founders who prioritize usabi
 - [JustBlogged](https://justblogged.com) - No-setup blogging platform. Start your blog in 2 minutes. Free plan available, $9/mo for Pro with custom domains and built-in SEO.
 
 - [Leado](https://leado.co) - AI-powered Reddit lead generation tool that monitors subreddits for high-intent conversations and automates outreach.
+- [Autoposting](https://autoposting.ai) - AI social media manager that writes posts in your voice, clips long video, and schedules to five networks.
 
 ## Productivity
 


### PR DESCRIPTION
Adds [Autoposting](https://autoposting.ai) to Marketing — AI social media manager that writes posts in your voice, clips long video, and schedules to five networks. Free tier available.

One line added, matching the section style.