### PR TITLE
Add Push or Pay to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Find lean, reliable software built by bootstrapped founders who prioritize usabi
 
 - [Motherboard](https://trymotherboard.com) - Motherboard brings all your key metrics into one dashboard. Works with any website. Saves you hours every week. Needs zero coding, click on any value to track.
 - [LookAway](https://lookaway.com) - LookAway is a smart break reminder that helps reduce eye strain, digital fatigue, and maintain better posture—so you can end your day feeling fresh.
+- [Push or Pay](https://push-or-pay.vercel.app) - A tiny accountability game for two. Skip your daily push-ups and your partner collects the Lazy Tax. No login, just a shared streak and a running joke.
 - [Scribbble](https://www.scribbble.app/) - Screen annotation app for presenters, content creators and online educators.
 - [TextSniper](https://textsniper.app/) - TextSniper extracts text from images, videos, PDFs and anything on your screen. Copy text where copying isn't allowed. Scan QR codes instantly.
 


### PR DESCRIPTION
Push or Pay is a lean, self-funded accountability app: two people, one daily push-up streak, no login (link + token based). Skip the reps and your partner collects the "Lazy Tax" — the whole mechanic is designed to be funny between partners, not guilt-driven. Live at https://push-or-pay.vercel.app.

Meets the quality bar:
- Bootstrapped, not VC-backed
- No login required to use the core loop
- Fast to try (single link, no signup form)
- Actively maintained