### PR TITLE
Add tingdo to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Find lean, reliable software built by bootstrapped founders who prioritize usabi
 - [LookAway](https://lookaway.com) - LookAway is a smart break reminder that helps reduce eye strain, digital fatigue, and maintain better posture—so you can end your day feeling fresh.
 - [Scribbble](https://www.scribbble.app/) - Screen annotation app for presenters, content creators and online educators.
 - [TextSniper](https://textsniper.app/) - TextSniper extracts text from images, videos, PDFs and anything on your screen. Copy text where copying isn't allowed. Scan QR codes instantly.
+- [tingdo](https://tingdo.app) - GTD task manager built around what's next instead of fake due dates. Tasks sit in lists sorted by situation and get reviewed weekly. Free tier available.
 
 ## Project Management
 


### PR DESCRIPTION
Adds tingdo, a GTD task manager, to Productivity.

## Checklist

- [x] I have starred the repository
- [x] The software is built by bootstrapped founders (not VC-backed)
- [x] The software prioritizes usability and user experience
- [x] The software offers fast, responsive customer support. (Don't have one? Try [Helploom](https://helploom.com) for free)
- [x] The software has sane, transparent pricing
- [x] The software is actively maintained and reliable
- [x] The entry follows the format: `- [Software Name](https://link) - Description.`
- [x] The entry is added at the last in the category
- [x] The link points to the official website and is working
- [x] No affiliate links are included
- [x] The description is clear and concise

## Additional Notes

Pricing is a public page with a free tier (5 projects, 3 contexts, no time limit, no credit card) plus paid plans — no hidden tiers or contact-us gating.

I put this under Productivity rather than the empty Project Management section, since tingdo is a personal task manager rather than a team collaboration tool like the Basecamp example in CONTRIBUTING. Happy to move it if you'd rather it sat there.

Disclosure: I work on tingdo.
