### PR TITLE
Add Ibis under Design

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Find lean, reliable software built by bootstrapped founders who prioritize usabi
 
 ## Design
 
+- [Ibis](https://cartonpliant.github.io/ibis/) - Compose a one-page commercial offer in the browser. Free with watermark; Pro 9€ for clean print, Markdown, and five layouts.
+
 ## Developer Tools
 
 - [NoParam](https://noparam.com) - Real-time email validation API to prevent fake signups, detect disposable addresses, and ensure deliverability.


### PR DESCRIPTION
Adds [Ibis](https://cartonpliant.github.io/ibis/).

Ibis is a static, no-account composer for a one-page commercial offer (not invoices, not quotes). Free with watermark; Pro is 9 € for clean print, Markdown, and 5 layouts.

I am the maker. Live URL: https://cartonpliant.github.io/ibis/
Repo: https://github.com/CartonPliant/ibis