### PR TITLE
Add Naratake to E-commerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Find lean, reliable software built by bootstrapped founders who prioritize usabi
 ## E-commerce
 
 - [HonorBox](https://honorboxx.github.io/honorbox/) - Sell digital products with just Stripe and GitHub: static storefront, checkout via Stripe Payment Links, delivery via private repo invites. MIT engine, $0/month, 0% platform fee.
+- [Naratake](https://naratake.com/en) - Website builder for restaurants, salons and trades that publishes a real Next.js site, with online ordering and bookings at 0% commission through your own Stripe. Free to build and preview; paid plans from $49/month.
 
 ## Finance & Accounting
 


### PR DESCRIPTION
Bootstrapped, no outside funding. Naratake builds websites for local businesses that take orders and bookings; card payments go through the owner's own Stripe account and Naratake takes 0% of sales.

Pricing is public and flat: free to build and preview, Storefront $49/month, Storefront Pro $79/month. No transaction fees, no per-order cut.

Added alphabetically within E-commerce, in the format given in CONTRIBUTING.md.